### PR TITLE
reflect the platform preparing shellscript usage

### DIFF
--- a/documentation/documentation.asc
+++ b/documentation/documentation.asc
@@ -3,43 +3,41 @@
 === Prepare the system
 
 * Download RHEL 8
-* Install (preferably with LVM, so that we can use boom for snapshotted fallbacks)
+* Install 
+** preferably with LVM, so that we can use boom for snapshotted fallbacks
+** have a user with sudo rights to run your first playbooks
 
-1st steps
+1st steps - we need: 
+* subscription for RHEL and Ansible 
+* Access to the Ansible repository
+* ANsible installed 
+* sudoers set up
+
+You'll find a shellscript that does most of this, before you have ansible available:  
 ----
 
-[root@nuclab ~]# subscription-manager register
-[root@nuclab ~]# subscription-manager auto-attach
+[root@nuclab scripts]# ./step0_platforprep.sh 
+Running as root, good...
+Testing subscription status
+...subscription looks good, let's move on...
+Checking if the ansible repo is enabled
+...it isn't. Trying to enable...
+...success.
+Checking if ansible is installed
+...it isn't, installing...
+...done
+Setting sudoers for the wheel group, if sudoers is unchanged
+...done.
+Updating entire system...
+...all good. You should reboot, and create a boom snapshot for fallback now.
+Ready to rock'n'roll, reboot, [consider the boom boot option] and run your playbooks.
+[root@nuclab scripts]# 
 
-[root@nuclab ~]# yum grouplist
-Updating Subscription Management repositories.
-Last metadata expiration check: 2:36:07 ago on Sa 19 Dez 2020 20:11:09 CET.
-Available Environment Groups:
-   Server with GUI
-   Server
-   Minimal Install
-   Workstation
-   Custom Operating System
-Installed Environment Groups:
-   Virtualization Host
-Installed Groups:
-   Container Management
-   Headless Management
-Available Groups:
-   RPM Development Tools
-   .NET Core Development
-   Scientific Support
-   Legacy UNIX Compatibility
-   System Tools
-   Development Tools
-   Security Tools
-   Smart Card Support
-   Network Servers
-   Graphical Administration Tools
+----
 
-[root@nuclab ~]# yum update
-[root@nuclab ~]# yum install ansible
-[root@nuclab ~]# yum install git
+We can create users manually too: 
+
+----
 
 [root@nuclab ~]# adduser mlapagna -U -G "wheel"
 [root@nuclab ~]# passwd mlapagna
@@ -94,3 +92,15 @@ Host nuclab
 
 ----
 
+After that you can run the roles in the ansible dir: 
+
+----
+
+ansible-playbook -i hosts.yml -b main.yml 
+
+----
+
+The roles do the following: 
+
+* dnsmasq: sets up dnsmasq required for RHV
+* base_packages: ensures that some basic RPMs are installed 


### PR DESCRIPTION
Have written a script for platform preparation, it's in the repository, I'd suggest we recommend using this to standardize the first steps after an eventual reinstall. 